### PR TITLE
Bugfix: Attempt a graceful close

### DIFF
--- a/lib/extendedApi.js
+++ b/lib/extendedApi.js
@@ -52,24 +52,13 @@ RedisClient.prototype.end = function (flush) {
         clearTimeout(this.retry_timer);
         this.retry_timer = null;
     }
-    this.stream.removeAllListeners();
-    this.stream.on('error', noop);
     this.connected = false;
     this.ready = false;
     this.closing = true;
-    // Flush queue if wanted
-    if (flush) {
-        this.flush_and_error({
-            message: 'Connection forcefully ended and command aborted.',
-            code: 'NR_CLOSED'
-        });
-    } else if (arguments.length === 0) {
-        this.warn(
-            'Using .end() without the flush parameter is deprecated and throws from v.3.0.0 on.\n' +
-            'Please check the doku (https://github.com/NodeRedis/node_redis) and explictly use flush.'
-        );
-    }
-    return this.stream.destroySoon();
+    // stream.end() just sends a TCP fin and waits for a corresponding FIN
+    // from the server, which denotes the closure, and triggers connection_gone(close)
+    // this will flush for us and close gracefully
+    this.stream.end();
 };
 
 RedisClient.prototype.unref = function () {

--- a/lib/extendedApi.js
+++ b/lib/extendedApi.js
@@ -47,6 +47,7 @@ RedisClient.prototype.send_command = RedisClient.prototype.sendCommand = functio
 };
 
 RedisClient.prototype.end = function (flush) {
+    const self = this;
     // Clear retry_timer
     if (this.retry_timer) {
         clearTimeout(this.retry_timer);
@@ -55,10 +56,28 @@ RedisClient.prototype.end = function (flush) {
     this.connected = false;
     this.ready = false;
     this.closing = true;
+
+    this.stream.removeAllListeners('close');
+
     // stream.end() just sends a TCP fin and waits for a corresponding FIN
     // from the server, which denotes the closure, and triggers connection_gone(close)
     // this will flush for us and close gracefully
-    this.stream.end();
+    // we also have a timeout for a less graceful close 5sec later
+    return new Promise((res, rej) => {
+        const timeout = setTimeout(() => {
+            this.stream.removeAllListeners('close');
+            this.stream.removeAllListeners('end');
+            self.connection_gone('end');
+            res();
+        }, 5000);
+        this.stream.once('close', function (hadError) {
+            clearTimeout(timeout);
+            self.connection_gone('close');
+            res();
+        });
+        this.stream.end();
+    })
+
 };
 
 RedisClient.prototype.unref = function () {


### PR DESCRIPTION
Replace call to deprecated `destroySoon` API which just kills connection outright, actually just do a graceful close when `end` is called.

Technically doesn't do the same as the original, but this is infinitely better suited to how it gets used in Cube (as cleanup from connection pool)